### PR TITLE
Fix regex meta characters breaking command handling

### DIFF
--- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
@@ -50,6 +50,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -659,7 +660,7 @@ public class CommandClientImpl implements CommandClient, EventListener
 
         if(parts!=null) //starts with valid prefix
         {
-            String[] prefixAndArgs = rawContent.split(parts[0]);
+            String[] prefixAndArgs = rawContent.split(Pattern.quote(parts[0]));
             String prefix = "";
             if (prefixAndArgs.length > 0)
                 prefix = prefixAndArgs[0];


### PR DESCRIPTION
Fixes stuff like `!?` throwing an error when the prefix is `!`
```
19:49:05.904 [JDA MainWS-ReadThread] ERROR net.dv8tion.jda.api.JDA - One of the EventListeners had an uncaught exception
java.util.regex.PatternSyntaxException: Dangling meta character '?' near index 0
?
^
	at java.util.regex.Pattern.error(Pattern.java:1969)
	at java.util.regex.Pattern.sequence(Pattern.java:2137)
	at java.util.regex.Pattern.expr(Pattern.java:2010)
	at java.util.regex.Pattern.compile(Pattern.java:1702)
	at java.util.regex.Pattern.<init>(Pattern.java:1352)
	at java.util.regex.Pattern.compile(Pattern.java:1028)
	at java.lang.String.split(String.java:2380)
	at java.lang.String.split(String.java:2422)
	at com.jagrosh.jdautilities.command.impl.CommandClientImpl.onMessageReceived(CommandClientImpl.java:662)
	at com.jagrosh.jdautilities.command.impl.CommandClientImpl.onEvent(CommandClientImpl.java:528)
	at net.dv8tion.jda.api.hooks.InterfacedEventManager.handle(InterfacedEventManager.java:96)
	at net.dv8tion.jda.internal.hooks.EventManagerProxy.handleInternally(EventManagerProxy.java:88)
	at net.dv8tion.jda.internal.hooks.EventManagerProxy.handle(EventManagerProxy.java:70)
	at net.dv8tion.jda.internal.JDAImpl.handleEvent(JDAImpl.java:160)
	at net.dv8tion.jda.internal.handle.MessageCreateHandler.handleInternally(MessageCreateHandler.java:123)
	at net.dv8tion.jda.internal.handle.SocketHandler.handle(SocketHandler.java:36)
	at net.dv8tion.jda.internal.requests.WebSocketClient.onDispatch(WebSocketClient.java:952)
	at net.dv8tion.jda.internal.requests.WebSocketClient.onEvent(WebSocketClient.java:839)
	at net.dv8tion.jda.internal.requests.WebSocketClient.handleEvent(WebSocketClient.java:817)
	at net.dv8tion.jda.internal.requests.WebSocketClient.onBinaryMessage(WebSocketClient.java:990)
	at com.neovisionaries.ws.client.ListenerManager.callOnBinaryMessage(ListenerManager.java:385)
	at com.neovisionaries.ws.client.ReadingThread.callOnBinaryMessage(ReadingThread.java:276)
	at com.neovisionaries.ws.client.ReadingThread.handleBinaryFrame(ReadingThread.java:996)
	at com.neovisionaries.ws.client.ReadingThread.handleFrame(ReadingThread.java:755)
	at com.neovisionaries.ws.client.ReadingThread.main(ReadingThread.java:108)
	at com.neovisionaries.ws.client.ReadingThread.runMain(ReadingThread.java:64)
	at com.neovisionaries.ws.client.WebSocketThread.run(WebSocketThread.java:45)
```