### PR TITLE
Changed Synchronized HashSet to ConcurrentHashMap's keySet

### DIFF
--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/waiter/EventWaiter.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/waiter/EventWaiter.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -207,7 +208,7 @@ public class EventWaiter implements EventListener
         Checks.notNull(action, "The provided action consumer");
 
         WaitingEvent we = new WaitingEvent<>(condition, action);
-        Set<WaitingEvent> set = waitingEvents.computeIfAbsent(classType, c -> Collections.synchronizedSet(new HashSet<>()));
+        Set<WaitingEvent> set = waitingEvents.computeIfAbsent(classType, c -> ConcurrentHashMap.newKeySet());
         set.add(we);
 
         if(timeout > 0 && unit != null)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [x] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `Commons` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

Describe your PR here.

Modified the WaitingEvent set to `ConcurrentHashMap.newKeySet()` to fix the odd behavior of `ConcurrentModificationException` errors when calling this method in recursive functions.