### PR TITLE
Improve OptionHelper methods

### DIFF
--- a/command/src/main/java/pw/chew/jdachewtils/command/OptionHelper.java
+++ b/command/src/main/java/pw/chew/jdachewtils/command/OptionHelper.java
@@ -345,7 +345,7 @@ public final class OptionHelper {
     }
 
     /**
-     * Will return if the provided key resolves into an available Option for the SlashCommand.
+     * Will return if the provided key resolves into a provided Option for the SlashCommand.
      *
      * @param event  the slash command event to get options from
      * @param key    the option we want

--- a/command/src/main/java/pw/chew/jdachewtils/command/OptionHelper.java
+++ b/command/src/main/java/pw/chew/jdachewtils/command/OptionHelper.java
@@ -48,7 +48,8 @@ import java.util.List;
  *    {@literal @Override}
  *     protected void execute(SlashCommandEvent event) {
  *         String arg1 = OptionHelper.optString(event, "string", null);
- *         User optionalUser = OptionHelper.optUser(event, "user", null);
+ *         // Get the provided user, or use the executor if they did not provide one
+ *         User optionalUser = OptionHelper.optUser(event, "user", event.getUser());
  *     }
  * }
  * </code></pre>

--- a/command/src/main/java/pw/chew/jdachewtils/command/OptionHelper.java
+++ b/command/src/main/java/pw/chew/jdachewtils/command/OptionHelper.java
@@ -30,173 +30,198 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 /**
- * A collection of useful methods for working with Options.
+ * Utility class containing useful methods for getting values of Slash command arguments.
+ * 
+ * <h2>Example</h2>
+ * <pre><code>
+ * public class MyCommand extends SlashCommand {
+ *     public MyCommand() {
+ *         this.name = "example";
+ *         this.help = "Example command";
+ *         
+ *         this.options = Arrays.asList(
+ *             new OptionData(OptionType.STRING, "string", "A String option").setRequired(true),
+ *             new OptionData(OptionType.USER, "user", "A optional User")
+ *         );
+ *     }
+ *     
+ *    {@literal @Override}
+ *     protected void execute(SlashCommandEvent event) {
+ *         String arg1 = OptionHelper.optString(event, "string", null);
+ *         User optionalUser = OptionHelper.optUser(event, "user", null);
+ *     }
+ * }
+ * </code></pre>
  */
 public final class OptionHelper {
     private OptionHelper() {}
 
     /**
-     * Guarantees a String option value by providing a default value.
+     * Gets the provided Option Key as a String value, or returns the default one if the option cannot be found.
      *
      * @param event        The slash command event to get options from
-     * @param option       The option we want
-     * @param defaultValue The fallback option in case of the absence of the option value
+     * @param key          The option we want
+     * @param defaultValue Nullable default value used in the absence of the option value
      * @return The provided option, or the default value if the option is not present
      */
     @Nullable
     @Contract("_, _, !null -> !null")
-    public static String optString(@NotNull SlashCommandEvent event, @NotNull String option, @Nullable String defaultValue) {
-        List<OptionMapping> options = event.getOptionsByName(option);
+    public static String optString(@NotNull SlashCommandEvent event, @NotNull String key, @Nullable String defaultValue) {
+        OptionMapping option = event.getOption(key);
 
-        return options.isEmpty() ? defaultValue : options.get(0).getAsString();
+        return option == null ? defaultValue : option.getAsString();
     }
 
     /**
-     * Guarantees a boolean option value by providing a default value.
+     * Gets the provided Option Key as a boolean value, or returns the default one if the option cannot be found.
      *
      * @param event        The slash command event to get options from
-     * @param option       The option we want
+     * @param key          The option we want
      * @param defaultValue The fallback option in case of the absence of the option value
      * @return The provided option, or the default value if the option is not present
      */
-    public static boolean optBoolean(@NotNull SlashCommandEvent event, @NotNull String option, boolean defaultValue) {
-        List<OptionMapping> options = event.getOptionsByName(option);
+    public static boolean optBoolean(@NotNull SlashCommandEvent event, @NotNull String key, boolean defaultValue) {
+        OptionMapping option = event.getOption(key);
 
-        return options.isEmpty() ? defaultValue : options.get(0).getAsBoolean();
+        return option == null ? defaultValue : option.getAsBoolean();
     }
 
     /**
-     * Guarantees a long option value by providing a default value.
+     * Gets the provided Option Key as a long value, or returns the default one if the option cannot be found.
      *
      * @param event        The slash command event to get options from
-     * @param option       The option we want
+     * @param key          The option we want
      * @param defaultValue The fallback option in case of the absence of the option value
      * @return The provided option, or the default value if the option is not present
      */
-    public static long optLong(@NotNull SlashCommandEvent event, @NotNull String option, long defaultValue) {
-        List<OptionMapping> options = event.getOptionsByName(option);
+    public static long optLong(@NotNull SlashCommandEvent event, @NotNull String key, long defaultValue) {
+        OptionMapping option = event.getOption(key);
 
-        return options.isEmpty() ? defaultValue : options.get(0).getAsLong();
+        return option == null ? defaultValue : option.getAsLong();
     }
 
     /**
-     * Guarantees a double option value by providing a default value.
+     * Gets the provided Option Key as a double value, or returns the default one if the option cannot be found.
      *
      * @param event        The slash command event to get options from
-     * @param option       The option we want
+     * @param key          The option we want
      * @param defaultValue The fallback option in case of the absence of the option value
      * @return The provided option, or the default value if the option is not present
      */
-    public static double optDouble(@NotNull SlashCommandEvent event, @NotNull String option, double defaultValue) {
-        List<OptionMapping> options = event.getOptionsByName(option);
+    public static double optDouble(@NotNull SlashCommandEvent event, @NotNull String key, double defaultValue) {
+        OptionMapping option = event.getOption(key);
 
-        return options.isEmpty() ? defaultValue : options.get(0).getAsDouble();
+        return option == null ? defaultValue : option.getAsDouble();
     }
 
     /**
-     * Guarantees a Guild Channel option value by providing a default value.
+     * Gets the provided Option Key as a GuildChannel value, or returns the default one if the option cannot be found.
      *
      * @param event        The slash command event to get options from
-     * @param option       The option we want
-     * @param defaultValue The fallback option in case of the absence of the option value
-     * @return The provided option, or the default value if the option is not present
-     */
-    @Nullable
-    @Contract("_, _, !null -> !null")
-    public static GuildChannel optGuildChannel(@NotNull SlashCommandEvent event, @NotNull String option, @Nullable GuildChannel defaultValue) {
-        List<OptionMapping> options = event.getOptionsByName(option);
-
-        return options.isEmpty() ? defaultValue : options.get(0).getAsGuildChannel();
-    }
-
-    /**
-     * Guarantees a Member option value by providing a default value.
-     *
-     * @param event        The slash command event to get options from
-     * @param option       The option we want
-     * @param defaultValue The fallback option in case of the absence of the option value
+     * @param key          The option we want
+     * @param defaultValue Nullable default value used in the absence of the option value
      * @return The provided option, or the default value if the option is not present
      */
     @Nullable
     @Contract("_, _, !null -> !null")
-    public static Member optMember(@NotNull SlashCommandEvent event, @NotNull String option, @Nullable Member defaultValue) {
-        List<OptionMapping> options = event.getOptionsByName(option);
+    public static GuildChannel optGuildChannel(@NotNull SlashCommandEvent event, @NotNull String key, @Nullable GuildChannel defaultValue) {
+        OptionMapping option = event.getOption(key);
 
-        return options.isEmpty() ? defaultValue : options.get(0).getAsMember();
+        return option == null ? defaultValue : option.getAsGuildChannel();
     }
 
     /**
-     * Guarantees a IMentionable option value by providing a default value.
+     * Gets the provided Option Key as a Member value, or returns the default one if the option cannot be found.
+     * <br>This will <b>always</b> return the default value when the SlashCommandEvent was not executed in a Guild.
      *
      * @param event        The slash command event to get options from
-     * @param option       The option we want
-     * @param defaultValue The fallback option in case of the absence of the option value
+     * @param key          The option we want
+     * @param defaultValue Nullable default value used in the absence of the option value
      * @return The provided option, or the default value if the option is not present
      */
     @Nullable
     @Contract("_, _, !null -> !null")
-    public static IMentionable optMentionable(@NotNull SlashCommandEvent event, @NotNull String option, @Nullable IMentionable defaultValue) {
-        List<OptionMapping> options = event.getOptionsByName(option);
+    public static Member optMember(@NotNull SlashCommandEvent event, @NotNull String key, @Nullable Member defaultValue) {
+        if (!event.isFromGuild())
+            return defaultValue; // Non-guild commands do not have a member.
+        
+        OptionMapping option = event.getOption(key);
 
-        return options.isEmpty() ? defaultValue : options.get(0).getAsMentionable();
+        return option == null ? defaultValue : option.getAsMember();
     }
 
     /**
-     * Guarantees a Role option value by providing a default value.
+     * Gets the provided Option Key as a IMentionable value, or returns the default one if the option cannot be found.
      *
      * @param event        The slash command event to get options from
-     * @param option       The option we want
-     * @param defaultValue The fallback option in case of the absence of the option value
+     * @param key          The option we want
+     * @param defaultValue Nullable default value used in the absence of the option value
      * @return The provided option, or the default value if the option is not present
      */
     @Nullable
     @Contract("_, _, !null -> !null")
-    public static Role optRole(@NotNull SlashCommandEvent event, @NotNull String option, @Nullable Role defaultValue) {
-        List<OptionMapping> options = event.getOptionsByName(option);
+    public static IMentionable optMentionable(@NotNull SlashCommandEvent event, @NotNull String key, @Nullable IMentionable defaultValue) {
+        OptionMapping option = event.getOption(key);
 
-        return options.isEmpty() ? defaultValue : options.get(0).getAsRole();
+        return option == null ? defaultValue : option.getAsMentionable();
     }
 
     /**
-     * Guarantees a User option value by providing a default value.
+     * Gets the provided Option Key as a Role value, or returns the default one if the option cannot be found.
      *
      * @param event        The slash command event to get options from
-     * @param option       The option we want
-     * @param defaultValue The fallback option in case of the absence of the option value
+     * @param key          The option we want
+     * @param defaultValue Nullable default value used in the absence of the option value
      * @return The provided option, or the default value if the option is not present
      */
     @Nullable
     @Contract("_, _, !null -> !null")
-    public static User optUser(@NotNull SlashCommandEvent event, @NotNull String option, @Nullable User defaultValue) {
-        List<OptionMapping> options = event.getOptionsByName(option);
+    public static Role optRole(@NotNull SlashCommandEvent event, @NotNull String key, @Nullable Role defaultValue) {
+        OptionMapping option = event.getOption(key);
 
-        return options.isEmpty() ? defaultValue : options.get(0).getAsUser();
+        return option == null ? defaultValue : option.getAsRole();
     }
 
     /**
-     * Guarantees a MessageChannel option value by providing a default value.
+     * Gets the provided Option Key as a User value, or returns the default one if the option cannot be found.
      *
      * @param event        The slash command event to get options from
-     * @param option       The option we want
-     * @param defaultValue The fallback option in case of the absence of the option value
+     * @param key          The option we want
+     * @param defaultValue Nullable default value used in the absence of the option value
      * @return The provided option, or the default value if the option is not present
      */
     @Nullable
     @Contract("_, _, !null -> !null")
-    public static MessageChannel optMessageChannel(@NotNull SlashCommandEvent event, @NotNull String option, @Nullable MessageChannel defaultValue) {
-        List<OptionMapping> options = event.getOptionsByName(option);
+    public static User optUser(@NotNull SlashCommandEvent event, @NotNull String key, @Nullable User defaultValue) {
+        OptionMapping option = event.getOption(key);
 
-        return options.isEmpty() ? defaultValue : options.get(0).getAsMessageChannel();
+        return option == null ? defaultValue : option.getAsUser();
     }
 
     /**
-     * Checks to see if the event has an option.
+     * Gets the provided Option Key as a MessageChannel value, or returns the default one if the option cannot be found.
+     *
+     * @param event        The slash command event to get options from
+     * @param key          The option we want
+     * @param defaultValue Nullable default value used in the absence of the option value
+     * @return The provided option, or the default value if the option is not present
+     */
+    @Nullable
+    @Contract("_, _, !null -> !null")
+    public static MessageChannel optMessageChannel(@NotNull SlashCommandEvent event, @NotNull String key, @Nullable MessageChannel defaultValue) {
+        OptionMapping option = event.getOption(key);
+
+        return option == null ? defaultValue : option.getAsMessageChannel();
+    }
+
+    /**
+     * Will return if the provided key resolves into an available Option for the SlashCommand.
      *
      * @param event  the slash command event to get options from
-     * @param option the option we want
+     * @param key    the option we want
      * @return true if the option exists, false otherwise
      */
-    public static boolean hasOption(@NotNull SlashCommandEvent event, @NotNull String option) {
-        return !event.getOptionsByName(option).isEmpty();
+    public static boolean hasOption(@NotNull SlashCommandEvent event, @NotNull String key) {
+        return event.getOption(key) != null;
     }
 }

--- a/command/src/main/java/pw/chew/jdachewtils/command/OptionHelper.java
+++ b/command/src/main/java/pw/chew/jdachewtils/command/OptionHelper.java
@@ -29,20 +29,20 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Utility class containing useful methods for getting values of Slash command arguments.
- * 
+ *
  * <h2>Example</h2>
  * <pre><code>
  * public class MyCommand extends SlashCommand {
  *     public MyCommand() {
  *         this.name = "example";
  *         this.help = "Example command";
- *         
+ *
  *         this.options = Arrays.asList(
  *             new OptionData(OptionType.STRING, "string", "A String option").setRequired(true),
  *             new OptionData(OptionType.USER, "user", "A optional User")
  *         );
  *     }
- *     
+ *
  *    {@literal @Override}
  *     protected void execute(SlashCommandEvent event) {
  *         // get "string" option as String. Defaults to null if not found
@@ -55,10 +55,10 @@ import org.jetbrains.annotations.Nullable;
  */
 public final class OptionHelper {
     private OptionHelper() {}
-    
+
     /**
      * Gets the provided Option Key as a String value, or returns {@code null} if the option cannot be found.
-     * 
+     *
      * @param event The slash command event to get options from
      * @param key   The option we want
      * @return The provided option, or null if the option is not present
@@ -67,7 +67,7 @@ public final class OptionHelper {
     public static String optString(@NotNull SlashCommandEvent event, @NotNull String key) {
         return optString(event, key, null);
     }
-    
+
     /**
      * Gets the provided Option Key as a String value, or returns the default one if the option cannot be found.
      *
@@ -83,7 +83,7 @@ public final class OptionHelper {
 
         return option == null ? defaultValue : option.getAsString();
     }
-    
+
     /**
      * Gets the provided Option Key as a boolean value, or returns {@code false} if the option cannot be found.
      *
@@ -94,7 +94,7 @@ public final class OptionHelper {
     public static boolean optBoolean(@NotNull SlashCommandEvent event, @NotNull String key) {
         return optBoolean(event, key, false);
     }
-    
+
     /**
      * Gets the provided Option Key as a boolean value, or returns the default one if the option cannot be found.
      *
@@ -108,7 +108,7 @@ public final class OptionHelper {
 
         return option == null ? defaultValue : option.getAsBoolean();
     }
-    
+
     /**
      * Gets the provided Option Key as a long value, or returns {@code 0} if the option cannot be found.
      *
@@ -119,7 +119,7 @@ public final class OptionHelper {
     public static long optLong(@NotNull SlashCommandEvent event, @NotNull String key) {
         return optLong(event, key, 0);
     }
-    
+
     /**
      * Gets the provided Option Key as a long value, or returns the default one if the option cannot be found.
      *
@@ -133,7 +133,7 @@ public final class OptionHelper {
 
         return option == null ? defaultValue : option.getAsLong();
     }
-    
+
     /**
      * Gets the provided Option Key as a double value, or returns {@code 0.0} if the option cannot be found.
      *
@@ -144,7 +144,7 @@ public final class OptionHelper {
     public static double optDouble(@NotNull SlashCommandEvent event, @NotNull String key) {
         return optDouble(event, key, 0.0);
     }
-    
+
     /**
      * Gets the provided Option Key as a double value, or returns the default one if the option cannot be found.
      *
@@ -158,7 +158,7 @@ public final class OptionHelper {
 
         return option == null ? defaultValue : option.getAsDouble();
     }
-    
+
     /**
      * Gets the provided Option Key as a GuildChannel value, or returns {@code null} if the option cannot be found.
      * <br>This will <b>always</b> return null when the SlashCommandEvent was not executed in a Guild.
@@ -186,12 +186,12 @@ public final class OptionHelper {
     public static GuildChannel optGuildChannel(@NotNull SlashCommandEvent event, @NotNull String key, @Nullable GuildChannel defaultValue) {
         if (!event.isFromGuild())
             return defaultValue;
-        
+
         OptionMapping option = event.getOption(key);
 
         return option == null ? defaultValue : option.getAsGuildChannel();
     }
-    
+
     /**
      * Gets the provided Option Key as a Member value, or returns {@code null} if the option cannot be found.
      * <br>This will <b>always</b> return null when the SlashCommandEvent was not executed in a Guild.
@@ -219,12 +219,12 @@ public final class OptionHelper {
     public static Member optMember(@NotNull SlashCommandEvent event, @NotNull String key, @Nullable Member defaultValue) {
         if (!event.isFromGuild())
             return defaultValue; // Non-guild commands do not have a member.
-        
+
         OptionMapping option = event.getOption(key);
 
         return option == null ? defaultValue : option.getAsMember();
     }
-    
+
     /**
      * Gets the provided Option Key as a IMentionable value, or returns {@code null} if the option cannot be found.
      *
@@ -236,7 +236,7 @@ public final class OptionHelper {
     public static IMentionable optMentionable(@NotNull SlashCommandEvent event, @NotNull String key) {
         return optMentionable(event, key, null);
     }
-    
+
     /**
      * Gets the provided Option Key as a IMentionable value, or returns the default one if the option cannot be found.
      *
@@ -252,7 +252,7 @@ public final class OptionHelper {
 
         return option == null ? defaultValue : option.getAsMentionable();
     }
-    
+
     /**
      * Gets the provided Option Key as a Role value, or returns {@code null} if the option cannot be found.
      * <br>This will <b>always</b> return null when the SlashCommandEvent was not executed in a Guild.
@@ -280,12 +280,12 @@ public final class OptionHelper {
     public static Role optRole(@NotNull SlashCommandEvent event, @NotNull String key, @Nullable Role defaultValue) {
         if (!event.isFromGuild())
             return defaultValue;
-        
+
         OptionMapping option = event.getOption(key);
 
         return option == null ? defaultValue : option.getAsRole();
     }
-    
+
     /**
      * Gets the provided Option Key as a User value, or returns {@code null} if the option cannot be found.
      *
@@ -313,7 +313,7 @@ public final class OptionHelper {
 
         return option == null ? defaultValue : option.getAsUser();
     }
-    
+
     /**
      * Gets the provided Option Key as a MessageChannel value, or returns {@code null} if the option cannot be found.
      *
@@ -345,8 +345,8 @@ public final class OptionHelper {
     /**
      * Will return if the provided key resolves into a provided Option for the SlashCommand.
      *
-     * @param event  the slash command event to get options from
-     * @param key    the option we want
+     * @param event the slash command event to get options from
+     * @param key   the option we want
      * @return true if the option exists, false otherwise
      */
     public static boolean hasOption(@NotNull SlashCommandEvent event, @NotNull String key) {

--- a/command/src/main/java/pw/chew/jdachewtils/command/OptionHelper.java
+++ b/command/src/main/java/pw/chew/jdachewtils/command/OptionHelper.java
@@ -117,6 +117,7 @@ public final class OptionHelper {
 
     /**
      * Gets the provided Option Key as a GuildChannel value, or returns the default one if the option cannot be found.
+     * <br>This will <b>always</b> return the default value when the SlashCommandEvent was not executed in a Guild.
      *
      * @param event        The slash command event to get options from
      * @param key          The option we want
@@ -126,6 +127,9 @@ public final class OptionHelper {
     @Nullable
     @Contract("_, _, !null -> !null")
     public static GuildChannel optGuildChannel(@NotNull SlashCommandEvent event, @NotNull String key, @Nullable GuildChannel defaultValue) {
+        if (!event.isFromGuild())
+            return defaultValue;
+        
         OptionMapping option = event.getOption(key);
 
         return option == null ? defaultValue : option.getAsGuildChannel();
@@ -169,6 +173,7 @@ public final class OptionHelper {
 
     /**
      * Gets the provided Option Key as a Role value, or returns the default one if the option cannot be found.
+     * <br>This will <b>always</b> return the default value when the SlashCommandEvent was not executed in a Guild.
      *
      * @param event        The slash command event to get options from
      * @param key          The option we want
@@ -178,6 +183,9 @@ public final class OptionHelper {
     @Nullable
     @Contract("_, _, !null -> !null")
     public static Role optRole(@NotNull SlashCommandEvent event, @NotNull String key, @Nullable Role defaultValue) {
+        if (!event.isFromGuild())
+            return defaultValue;
+        
         OptionMapping option = event.getOption(key);
 
         return option == null ? defaultValue : option.getAsRole();

--- a/command/src/main/java/pw/chew/jdachewtils/command/OptionHelper.java
+++ b/command/src/main/java/pw/chew/jdachewtils/command/OptionHelper.java
@@ -27,8 +27,6 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
-
 /**
  * Utility class containing useful methods for getting values of Slash command arguments.
  * 

--- a/command/src/main/java/pw/chew/jdachewtils/command/OptionHelper.java
+++ b/command/src/main/java/pw/chew/jdachewtils/command/OptionHelper.java
@@ -47,7 +47,8 @@ import java.util.List;
  *     
  *    {@literal @Override}
  *     protected void execute(SlashCommandEvent event) {
- *         String arg1 = OptionHelper.optString(event, "string", null);
+ *         // get "string" option as String. Defaults to null if not found
+ *         String arg1 = OptionHelper.optString(event, "string");
  *         // Get the provided user, or use the executor if they did not provide one
  *         User optionalUser = OptionHelper.optUser(event, "user", event.getUser());
  *     }
@@ -56,7 +57,19 @@ import java.util.List;
  */
 public final class OptionHelper {
     private OptionHelper() {}
-
+    
+    /**
+     * Gets the provided Option Key as a String value, or returns {@code null} if the option cannot be found.
+     * 
+     * @param event The slash command event to get options from
+     * @param key   The option we want
+     * @return The provided option, or null if the option is not present
+     */
+    @Nullable
+    public static String optString(@NotNull SlashCommandEvent event, @NotNull String key) {
+        return optString(event, key, null);
+    }
+    
     /**
      * Gets the provided Option Key as a String value, or returns the default one if the option cannot be found.
      *
@@ -72,7 +85,18 @@ public final class OptionHelper {
 
         return option == null ? defaultValue : option.getAsString();
     }
-
+    
+    /**
+     * Gets the provided Option Key as a boolean value, or returns {@code false} if the option cannot be found.
+     *
+     * @param event The slash command event to get options from
+     * @param key   The option we want
+     * @return The provided option, or false if the option is not present
+     */
+    public static boolean optBoolean(@NotNull SlashCommandEvent event, @NotNull String key) {
+        return optBoolean(event, key, false);
+    }
+    
     /**
      * Gets the provided Option Key as a boolean value, or returns the default one if the option cannot be found.
      *
@@ -86,7 +110,18 @@ public final class OptionHelper {
 
         return option == null ? defaultValue : option.getAsBoolean();
     }
-
+    
+    /**
+     * Gets the provided Option Key as a long value, or returns {@code 0} if the option cannot be found.
+     *
+     * @param event The slash command event to get options from
+     * @param key   The option we want
+     * @return The provided option, or 0 if the option is not present
+     */
+    public static long optLong(@NotNull SlashCommandEvent event, @NotNull String key) {
+        return optLong(event, key, 0);
+    }
+    
     /**
      * Gets the provided Option Key as a long value, or returns the default one if the option cannot be found.
      *
@@ -100,7 +135,18 @@ public final class OptionHelper {
 
         return option == null ? defaultValue : option.getAsLong();
     }
-
+    
+    /**
+     * Gets the provided Option Key as a double value, or returns {@code 0.0} if the option cannot be found.
+     *
+     * @param event The slash command event to get options from
+     * @param key   The option we want
+     * @return The provided option, or 0.0 if the option is not present
+     */
+    public static double optDouble(@NotNull SlashCommandEvent event, @NotNull String key) {
+        return optDouble(event, key, 0.0);
+    }
+    
     /**
      * Gets the provided Option Key as a double value, or returns the default one if the option cannot be found.
      *
@@ -113,6 +159,19 @@ public final class OptionHelper {
         OptionMapping option = event.getOption(key);
 
         return option == null ? defaultValue : option.getAsDouble();
+    }
+    
+    /**
+     * Gets the provided Option Key as a GuildChannel value, or returns {@code null} if the option cannot be found.
+     * <br>This will <b>always</b> return null when the SlashCommandEvent was not executed in a Guild.
+     *
+     * @param event The slash command event to get options from
+     * @param key   The option we want
+     * @return The provided option, or null if the option is not present
+     */
+    @Nullable
+    public static GuildChannel optGuildChannel(@NotNull SlashCommandEvent event, @NotNull String key) {
+        return optGuildChannel(event, key, null);
     }
 
     /**
@@ -134,6 +193,19 @@ public final class OptionHelper {
 
         return option == null ? defaultValue : option.getAsGuildChannel();
     }
+    
+    /**
+     * Gets the provided Option Key as a Member value, or returns {@code null} if the option cannot be found.
+     * <br>This will <b>always</b> return null when the SlashCommandEvent was not executed in a Guild.
+     *
+     * @param event The slash command event to get options from
+     * @param key   The option we want
+     * @return The provided option, or null if the option is not present
+     */
+    @Nullable
+    public static Member optMember(@NotNull SlashCommandEvent event, @NotNull String key) {
+        return optMember(event, key, null);
+    }
 
     /**
      * Gets the provided Option Key as a Member value, or returns the default one if the option cannot be found.
@@ -154,7 +226,19 @@ public final class OptionHelper {
 
         return option == null ? defaultValue : option.getAsMember();
     }
-
+    
+    /**
+     * Gets the provided Option Key as a IMentionable value, or returns {@code null} if the option cannot be found.
+     *
+     * @param event The slash command event to get options from
+     * @param key   The option we want
+     * @return The provided option, or null if the option is not present
+     */
+    @Nullable
+    public static IMentionable optMentionable(@NotNull SlashCommandEvent event, @NotNull String key) {
+        return optMentionable(event, key, null);
+    }
+    
     /**
      * Gets the provided Option Key as a IMentionable value, or returns the default one if the option cannot be found.
      *
@@ -169,6 +253,19 @@ public final class OptionHelper {
         OptionMapping option = event.getOption(key);
 
         return option == null ? defaultValue : option.getAsMentionable();
+    }
+    
+    /**
+     * Gets the provided Option Key as a Role value, or returns {@code null} if the option cannot be found.
+     * <br>This will <b>always</b> return null when the SlashCommandEvent was not executed in a Guild.
+     *
+     * @param event The slash command event to get options from
+     * @param key   The option we want
+     * @return The provided option, or null if the option is not present
+     */
+    @Nullable
+    public static Role optRole(@NotNull SlashCommandEvent event, @NotNull String key) {
+        return optRole(event, key, null);
     }
 
     /**
@@ -190,6 +287,18 @@ public final class OptionHelper {
 
         return option == null ? defaultValue : option.getAsRole();
     }
+    
+    /**
+     * Gets the provided Option Key as a User value, or returns {@code null} if the option cannot be found.
+     *
+     * @param event The slash command event to get options from
+     * @param key   The option we want
+     * @return The provided option, or null if the option is not present
+     */
+    @Nullable
+    public static User optUser(@NotNull SlashCommandEvent event, @NotNull String key) {
+        return optUser(event, key, null);
+    }
 
     /**
      * Gets the provided Option Key as a User value, or returns the default one if the option cannot be found.
@@ -205,6 +314,18 @@ public final class OptionHelper {
         OptionMapping option = event.getOption(key);
 
         return option == null ? defaultValue : option.getAsUser();
+    }
+    
+    /**
+     * Gets the provided Option Key as a MessageChannel value, or returns {@code null} if the option cannot be found.
+     *
+     * @param event The slash command event to get options from
+     * @param key   The option we want
+     * @return The provided option, or null if the option is not present
+     */
+    @Nullable
+    public static MessageChannel optMessageChannel(@NotNull SlashCommandEvent event, @NotNull String key) {
+        return optMessageChannel(event, key, null);
     }
 
     /**


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [ ] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `Commands` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

Improves the methods within the OptionHelper class as follows:

- Switch from `List<OptionMapping> options = event.getOptionsByName(option);` to `OptionMapping option = event.getOption(key);` since JDAs `getOption` essentially does what the Option Helper did.
  - Also, the return has been updated too and now checks if option is null rather than empty.
- Made `optMember` always return default value when the command was not executed in a Guild. Just to remove pointless get-calls that only return null.
- Improved documentation to make some info more clear and gave an example use-case in the class' description.
