### PR TITLE
Fix of the default prefix @mention that was no longer responding to commands

### DIFF
--- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
@@ -666,7 +666,7 @@ public class CommandClientImpl implements CommandClient, EventListener
         if(prefix.equals(DEFAULT_PREFIX) || (altprefix != null && altprefix.equals(DEFAULT_PREFIX))) {
             if(rawContent.startsWith("<@"+ event.getJDA().getSelfUser().getId()+">") ||
                     rawContent.startsWith("<@!"+ event.getJDA().getSelfUser().getId()+">")) {
-                final int prefixLength = rawContent.indexOf('>') + 1;
+                final int prefixLength = rawContent.indexOf('>') + 2;
                 return makeMessageParts(rawContent, prefixLength);
             }
         }

--- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
@@ -666,6 +666,9 @@ public class CommandClientImpl implements CommandClient, EventListener
         if(prefix.equals(DEFAULT_PREFIX) || (altprefix != null && altprefix.equals(DEFAULT_PREFIX))) {
             if(rawContent.startsWith("<@"+ event.getJDA().getSelfUser().getId()+">") ||
                     rawContent.startsWith("<@!"+ event.getJDA().getSelfUser().getId()+">")) {
+                // Since we now use substring into makeMessageParts function and a indexOf here, we need to do a +1 to get the good substring
+                // On top of that we need to do another +1 because the default @mention prefix will always be followed by a space
+                // So we need to add 2 characters to get the correct substring
                 final int prefixLength = rawContent.indexOf('>') + 2;
                 return makeMessageParts(rawContent, prefixLength);
             }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [x] My PR fixes a bug, error, or other issue with the library's codebase.
- [ ] My PR is for the `______` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

Fix the bug https://github.com/Chew/JDA-Chewtils/issues/39 introduced in pr https://github.com/Chew/JDA-Chewtils/pull/13

The default @mention prefix will always be followed by a space since it's a mention. 
Meaning this space is part of the prefix ! 
So need to add into counter the `>` character and the space, so 2 characters

![image](https://user-images.githubusercontent.com/25805069/145697271-8276e2c8-f612-4fe2-80e5-dd0002e9fbf5.png)

as the `makeMessageParts` use `substring(prefixLength, i)` it detect the whitespace as the command and the real command as the argument...

![image](https://user-images.githubusercontent.com/25805069/145697303-6c2f53cc-fa4d-4c72-8341-7fc9249dddce.png)


Related code : 

[makeMessageParts into CommandClientImpl.java  lines 739-L752](https://github.com/freya022/JDA-Chewtils/blob/f5d904a3ac3cbd2846970802ff260098f68ed10f/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java#L739-L752)