### PR TITLE
Issues/60

### DIFF
--- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
@@ -822,7 +822,7 @@ public class CommandClientImpl implements CommandClient, EventListener
             if(rawContent.startsWith("<@"+ event.getJDA().getSelfUser().getId()+">") ||
                     rawContent.startsWith("<@!"+ event.getJDA().getSelfUser().getId()+">")) {
                 // Since we now use substring into makeMessageParts function and a indexOf here, we need to do a +1 to get the good substring
-                final var mentionEndIndex = rawContent.indexOf('>') + 1;
+                final int mentionEndIndex = rawContent.indexOf('>') + 1;
                 // Make sure that the content isn't just the mention
                 if (rawContent.length() >= mentionEndIndex + 1) {
                     // On top of that we need to do another +1 because the default @mention prefix will always be followed by a space

--- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
@@ -822,10 +822,13 @@ public class CommandClientImpl implements CommandClient, EventListener
             if(rawContent.startsWith("<@"+ event.getJDA().getSelfUser().getId()+">") ||
                     rawContent.startsWith("<@!"+ event.getJDA().getSelfUser().getId()+">")) {
                 // Since we now use substring into makeMessageParts function and a indexOf here, we need to do a +1 to get the good substring
-                // On top of that we need to do another +1 because the default @mention prefix will always be followed by a space
-                // So we need to add 2 characters to get the correct substring
-                final int prefixLength = rawContent.indexOf('>') + 2;
-                return makeMessageParts(rawContent, prefixLength);
+                final var mentionEndIndex = rawContent.indexOf('>') + 1;
+                // Make sure that the content isn't just the mention
+                if (rawContent.length() >= mentionEndIndex + 1) {
+                    // On top of that we need to do another +1 because the default @mention prefix will always be followed by a space
+                    final int prefixLength = rawContent.indexOf('>') + 2;
+                    return makeMessageParts(rawContent, prefixLength);
+                }
             }
         }
 

--- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
@@ -819,8 +819,8 @@ public class CommandClientImpl implements CommandClient, EventListener
 
         // Check for prefix or alternate prefix (@mention cases)
         if(prefix.equals(DEFAULT_PREFIX) || (altprefix != null && altprefix.equals(DEFAULT_PREFIX))) {
-            if(rawContent.startsWith("<@"+ event.getJDA().getSelfUser().getId()+">") ||
-                    rawContent.startsWith("<@!"+ event.getJDA().getSelfUser().getId()+">")) {
+            if(rawContent.startsWith("<@"+ event.getJDA().getSelfUser().getId()+"> ") || //Ensure that there is a space between the command and the mention
+                    rawContent.startsWith("<@!"+ event.getJDA().getSelfUser().getId()+"> ")) {
                 // Since we now use substring into makeMessageParts function and a indexOf here, we need to do a +1 to get the good substring
                 final int mentionEndIndex = rawContent.indexOf('>') + 1;
                 // Make sure that the content isn't just the mention


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [x] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `command` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `____`.

#### Description
Currently, `CommandClientImpl#getParts` always expects a space after a mention, and such, it crashes with a `StringIndexOutOfBoundsException` when the message is just a ping. This PR fixes that by checking the length of the string before continuing.

Closes #60 
