### PR TITLE
Correct mistake in JavaDocs (SlashCommand)

### DIFF
--- a/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
@@ -45,7 +45,7 @@ import java.util.Map;
  * <a href="https://github.com/Chew/JDA-Chewtils/wiki/Command-to-SlashCommand-Migration">here</a>.</p>
  * {@link SlashCommand#execute(SlashCommandEvent) #execute(CommandEvent)} body:
  *
- * <pre><code> public class ExampleCmd extends Command {
+ * <pre><code> public class ExampleCmd extends SlashCommand {
  *
  *      public ExampleCmd() {
  *          this.name = "example";


### PR DESCRIPTION
In the code example, it extended Command not SlashCommand

[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [x] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `Command` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

Replaces `extend Command` with `extend SlashCommand` in the JavaDocs example for Slash Commands.
