### PR TITLE
Initial support for interactions in voice text channels

### DIFF
--- a/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommandEvent.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommandEvent.java
@@ -351,4 +351,19 @@ public class SlashCommandEvent extends SlashCommandInteractionEvent {
     {
         return getChannelType() == channelType;
     }
+
+    @Override
+    @NotNull
+    public ChannelType getChannelType()
+    {
+        ChannelType type;
+        try {
+            type = super.getChannelType();
+        } catch (ClassCastException e) {
+            // Probably voice
+            type = ChannelType.VOICE;
+        }
+
+        return type;
+    }
 }


### PR DESCRIPTION
Allows for slash commands to be ran inside Voice Text channels.

Drawbacks:
- Must enable `.setRawEventsEnabled(true)` in `JDABuilder`
- Any usage of `getChannel()` will NOT work. No way around this, unfortunately.
- Textual commands are unsupported.