### PR TITLE
Support for JDA 5.0.0-alpha.18 (Message Refactor)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ allprojects {
         junitVersion = '4.13.1' // TODO Move to junit 5?
 
         dependencies {
-            jda = { [group: 'com.github.DV8FromTheWorld', name: 'JDA', version: jdaVersion] }
+            jda = { [group: 'net.dv8tion', name: 'JDA', version: jdaVersion] }
             slf4j = { [group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion] }
             okhttp = { [group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion] }
             findbugs = { [group: 'com.google.code.findbugs', name: 'jsr305', version: findbugsVersion] }

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
     version = versionInfo.values().join('.')
 
     ext {
-        jdaVersion = 'e111d55'
+        jdaVersion = '5.0.0-alpha.18'
         slf4jVersion = '1.7.36'
         okhttpVersion = '4.9.3'
         findbugsVersion = '3.0.2'
@@ -91,7 +91,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        maven { url = "https://jitpack.io/" }
     }
 
     build {

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
     version = versionInfo.values().join('.')
 
     ext {
-        jdaVersion = '5.0.0-alpha.15'
+        jdaVersion = 'e111d55'
         slf4jVersion = '1.7.36'
         okhttpVersion = '4.9.3'
         findbugsVersion = '3.0.2'
@@ -44,7 +44,7 @@ allprojects {
         junitVersion = '4.13.1' // TODO Move to junit 5?
 
         dependencies {
-            jda = { [group: 'net.dv8tion', name: 'JDA', version: jdaVersion] }
+            jda = { [group: 'com.github.DV8FromTheWorld', name: 'JDA', version: jdaVersion] }
             slf4j = { [group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion] }
             okhttp = { [group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion] }
             findbugs = { [group: 'com.google.code.findbugs', name: 'jsr305', version: findbugsVersion] }
@@ -91,6 +91,7 @@ allprojects {
 
     repositories {
         mavenCentral()
+        maven { url = "https://jitpack.io/" }
     }
 
     build {

--- a/command/src/main/java/com/jagrosh/jdautilities/command/CommandEvent.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/CommandEvent.java
@@ -25,6 +25,8 @@ import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.exceptions.PermissionException;
+import net.dv8tion.jda.api.utils.FileUpload;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import net.dv8tion.jda.internal.utils.Checks;
 
 /**
@@ -127,7 +129,7 @@ public class CommandEvent
      * contained by this CommandEvent.
      *
      * <p>This method is exposed for those who wish to use linked deletion but may require usage of
-     * {@link net.dv8tion.jda.api.entities.MessageChannel#sendMessage(Message) MessageChannel#sendMessage()}
+     * {@link net.dv8tion.jda.api.entities.MessageChannel#sendMessage(MessageCreateData) MessageChannel#sendMessage()}
      * or for other reasons cannot use the standard {@code reply()} methods.
      *
      * <p>If the Message provided is <b>not</b> from the bot (IE: {@link net.dv8tion.jda.api.entities.SelfUser SelfUser}),
@@ -287,7 +289,7 @@ public class CommandEvent
      * @param  message
      *         The Message to reply with
      */
-    public void reply(Message message)
+    public void reply(MessageCreateData message)
     {
         event.getChannel().sendMessage(message).queue(m -> {
             if(event.isFromType(ChannelType.TEXT))
@@ -309,7 +311,7 @@ public class CommandEvent
      * @param  success
      *         The Consumer to success after sending the Message is sent.
      */
-    public void reply(Message message, Consumer<Message> success)
+    public void reply(MessageCreateData message, Consumer<Message> success)
     {
         event.getChannel().sendMessage(message).queue(m -> {
             if(event.isFromType(ChannelType.TEXT))
@@ -334,7 +336,7 @@ public class CommandEvent
      * @param  failure
      *         The Consumer to run if an error occurs when sending the Message.
      */
-    public void reply(Message message, Consumer<Message> success, Consumer<Throwable> failure)
+    public void reply(MessageCreateData message, Consumer<Message> success, Consumer<Throwable> failure)
     {
         event.getChannel().sendMessage(message).queue(m -> {
             if(event.isFromType(ChannelType.TEXT))
@@ -351,7 +353,7 @@ public class CommandEvent
      * sending the response as a {@link net.dv8tion.jda.api.entities.Message Message}
      * automatically does {@link net.dv8tion.jda.api.requests.RestAction#queue() RestAction#queue()}.
      * 
-     * <p>This method uses {@link net.dv8tion.jda.api.entities.MessageChannel#sendFile(File, String, net.dv8tion.jda.api.utils.AttachmentOption...) MessageChannel#sendFile(File, String, AttachmentOption...)}
+     * <p>This method uses {@link net.dv8tion.jda.api.entities.MessageChannel#sendFiles(FileUpload...) MessageChannel#sendFile(FileUpload...)}
      * to send the File. For more information on what a bot may send using this, you may find the info in that method.
      * 
      * @param  file
@@ -361,7 +363,7 @@ public class CommandEvent
      */
     public void reply(File file, String filename)
     {
-        event.getChannel().sendFile(file, filename).queue();
+        event.getChannel().sendFiles(FileUpload.fromData(file, filename)).queue();
     }
     
     /**
@@ -372,7 +374,7 @@ public class CommandEvent
      * sending the response as a {@link net.dv8tion.jda.api.entities.Message Message}
      * automatically does {@link net.dv8tion.jda.api.requests.RestAction#queue() RestAction#queue()}.
      * 
-     * <p>This method uses {@link net.dv8tion.jda.api.entities.MessageChannel#sendFile(File, String, net.dv8tion.jda.api.utils.AttachmentOption...) MessageChannel#sendFile(File, String, AttachmentOption...)}
+     * <p>This method uses {@link net.dv8tion.jda.api.entities.MessageChannel#sendFiles(FileUpload...) MessageChannel#sendFile(FileUpload...)}
      * to send the File. For more information on what a bot may send using this, you may find the info in that method.
      * 
      * @param  message
@@ -384,7 +386,7 @@ public class CommandEvent
      */
     public void reply(String message, File file, String filename)
     {
-        event.getChannel().sendFile(file, filename).content(message).queue();
+        event.getChannel().sendFiles(FileUpload.fromData(file, filename)).addContent(message).queue();
     }
     
     /**
@@ -440,7 +442,7 @@ public class CommandEvent
      * sending the response as a {@link net.dv8tion.jda.api.entities.Message Message}
      * automatically does {@link net.dv8tion.jda.api.requests.RestAction#queue() RestAction#queue()}.
      * 
-     * <p>This method uses {@link net.dv8tion.jda.api.entities.MessageChannel#sendFile(File, String, net.dv8tion.jda.api.utils.AttachmentOption...) MessageChannel#sendFile(File, String, AttachmentOption...)}
+     * <p>This method uses {@link net.dv8tion.jda.api.entities.MessageChannel#sendFiles(FileUpload...) MessageChannel#sendFile(FileUpload...)}
      * to send the File. For more information on what a bot may send using this, you may find the info in that method.
      * 
      * <p><b>NOTE:</b> This alternate String message can exceed the 2000 character cap, and will 
@@ -463,7 +465,7 @@ public class CommandEvent
     public void replyOrAlternate(String message, File file, String filename, String alternateMessage)
     {
         try {
-            event.getChannel().sendFile(file, filename).content(message).queue();
+            event.getChannel().sendFiles(FileUpload.fromData(file, filename)).addContent(message).queue();
         } catch(Exception e) {
             reply(alternateMessage);
         }
@@ -652,7 +654,7 @@ public class CommandEvent
      * @param  message
      *         The Message to reply with
      */
-    public void replyInDm(Message message)
+    public void replyInDm(MessageCreateData message)
     {
         if(event.isFromType(ChannelType.PRIVATE))
             reply(message);
@@ -679,7 +681,7 @@ public class CommandEvent
      * @param  success
      *         The Consumer to queue after sending the Message is sent.
      */
-    public void replyInDm(Message message, Consumer<Message> success)
+    public void replyInDm(MessageCreateData message, Consumer<Message> success)
     {
         if(event.isFromType(ChannelType.PRIVATE))
             getPrivateChannel().sendMessage(message).queue(success);
@@ -711,10 +713,10 @@ public class CommandEvent
     public void replyInDm(Message message, Consumer<Message> success, Consumer<Throwable> failure)
     {
         if(event.isFromType(ChannelType.PRIVATE))
-            getPrivateChannel().sendMessage(message).queue(success, failure);
+            getPrivateChannel().sendMessage(MessageCreateData.fromMessage(message)).queue(success, failure);
         else
         {
-            event.getAuthor().openPrivateChannel().queue(pc -> pc.sendMessage(message).queue(success, failure), failure);
+            event.getAuthor().openPrivateChannel().queue(pc -> pc.sendMessage(MessageCreateData.fromMessage(message)).queue(success, failure), failure);
         }
     }
 
@@ -730,7 +732,7 @@ public class CommandEvent
      * sending the response as a {@link net.dv8tion.jda.api.entities.Message Message}
      * automatically does {@link net.dv8tion.jda.api.requests.RestAction#queue() RestAction#queue()}.
      * 
-     * <p>This method uses {@link net.dv8tion.jda.api.entities.MessageChannel#sendFile(File, String, net.dv8tion.jda.api.utils.AttachmentOption...) MessageChannel#sendFile(File, String, AttachmentOption...)}
+     * <p>This method uses {@link net.dv8tion.jda.api.entities.MessageChannel#sendFiles(FileUpload...) MessageChannel#sendFile(FileUpload...)}
      * to send the File. For more information on what a bot may send using this, you may find the info in that method.
      * 
      * @param  message
@@ -746,7 +748,7 @@ public class CommandEvent
             reply(message, file, filename);
         else
         {
-            event.getAuthor().openPrivateChannel().queue(pc -> pc.sendFile(file, filename).content(message).queue());
+            event.getAuthor().openPrivateChannel().queue(pc -> pc.sendFiles(FileUpload.fromData(file, filename)).addContent(message).queue());
         }
     }
     

--- a/command/src/main/java/com/jagrosh/jdautilities/command/MessageContextMenuEvent.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/MessageContextMenuEvent.java
@@ -23,7 +23,8 @@ import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionE
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.context.MessageContextInteraction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
-import net.dv8tion.jda.api.utils.AttachmentOption;
+import net.dv8tion.jda.api.utils.FileUpload;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -119,7 +120,7 @@ public class MessageContextMenuEvent extends MessageContextInteractionEvent
      *
      * @param message The Message to reply with
      */
-    public void respond(Message message)
+    public void respond(MessageCreateData message)
     {
         reply(message).queue();
     }
@@ -130,16 +131,24 @@ public class MessageContextMenuEvent extends MessageContextInteractionEvent
      * <p>The {@link ReplyCallbackAction} returned by sending the response as a {@link Message} automatically does
      * {@link ReplyCallbackAction#queue() RestAction#queue()}.
      *
-     * <p>This method uses {@link GenericCommandInteractionEvent#replyFile(File, String, net.dv8tion.jda.api.utils.AttachmentOption...)}
+     * <p>This method uses {@link GenericCommandInteractionEvent#replyFiles(net.dv8tion.jda.api.utils.FileUpload...)}
      * to send the File. For more information on what a bot may send using this, you may find the info in that method.
      *
      * @param file The File to reply with
      * @param filename The filename that Discord should display (null for default).
-     * @param options The {@link AttachmentOption}s to apply to the File.
+     * @param description The description to set (null for no description).
+     * @param spoiler whether the file should be marked as spoiler.
      */
-    public void respond(File file, String filename, AttachmentOption... options)
+    public void respond(File file, String filename, String description, boolean spoiler)
     {
-        replyFile(file, filename, options).queue();
+        FileUpload fileUpload = FileUpload.fromData(file, filename);
+        if(description != null && !description.isEmpty())
+            fileUpload.setDescription(description);
+        
+        if(spoiler)
+            fileUpload.asSpoiler();
+        
+        replyFiles(fileUpload).queue();
     }
 
     /**

--- a/command/src/main/java/com/jagrosh/jdautilities/command/UserContextMenuEvent.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/UserContextMenuEvent.java
@@ -23,7 +23,8 @@ import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionE
 import net.dv8tion.jda.api.events.interaction.command.UserContextInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.context.UserContextInteraction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
-import net.dv8tion.jda.api.utils.AttachmentOption;
+import net.dv8tion.jda.api.utils.FileUpload;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -82,7 +83,7 @@ public class UserContextMenuEvent extends UserContextInteractionEvent
      *
      * @param message The Message to reply with
      */
-    public void respond(Message message)
+    public void respond(MessageCreateData message)
     {
         reply(message).queue();
     }
@@ -93,16 +94,24 @@ public class UserContextMenuEvent extends UserContextInteractionEvent
      * <p>The {@link ReplyCallbackAction} returned by sending the response as a {@link Message} automatically does
      * {@link ReplyCallbackAction#queue() RestAction#queue()}.
      *
-     * <p>This method uses {@link GenericCommandInteractionEvent#replyFile(File, String, AttachmentOption...)}
+     * <p>This method uses {@link GenericCommandInteractionEvent#replyFiles(FileUpload...)}
      * to send the File. For more information on what a bot may send using this, you may find the info in that method.
      *
      * @param file The File to reply with
      * @param filename The filename that Discord should display (null for default).
-     * @param options The {@link AttachmentOption}s to apply to the File.
+     * @param description The description to set (null for no description).
+     * @param spoiler whether the file should be marked as spoiler.
      */
-    public void respond(File file, String filename, AttachmentOption... options)
+    public void respond(File file, String filename, String description, boolean spoiler)
     {
-        replyFile(file, filename, options).queue();
+        FileUpload fileUpload = FileUpload.fromData(file, filename);
+        if(description != null && !description.isEmpty())
+            fileUpload.setDescription(description);
+        
+        if(spoiler)
+            fileUpload.asSpoiler();
+        
+        replyFiles(fileUpload).queue();
     }
 
     /**

--- a/examples/src/main/java/com/jagrosh/jdautilities/examples/command/RoleinfoCommand.java
+++ b/examples/src/main/java/com/jagrosh/jdautilities/examples/command/RoleinfoCommand.java
@@ -24,10 +24,10 @@ import java.util.List;
 import java.util.Locale;
 
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 
 /**
  *
@@ -98,8 +98,8 @@ public class RoleinfoCommand extends Command
         if(list.size() * 24 <= 2048-desr.length())
             list.forEach(m -> desr.append("<@").append(m.getUser().getId()).append("> "));
         
-        event.reply(new MessageBuilder()
-                .append(title)
+        event.reply(new MessageCreateBuilder()
+                .setContent(title)
                 .setEmbeds(new EmbedBuilder()
                         .setDescription(desr.toString().trim())
                         .setColor(role.getColor()).build())

--- a/examples/src/main/java/com/jagrosh/jdautilities/examples/command/ServerinfoCommand.java
+++ b/examples/src/main/java/com/jagrosh/jdautilities/examples/command/ServerinfoCommand.java
@@ -19,11 +19,11 @@ import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import java.time.format.DateTimeFormatter;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 
 /**
  *
@@ -86,6 +86,6 @@ public class ServerinfoCommand extends Command
             builder.setThumbnail(guild.getIconUrl());
         builder.setColor(owner == null ? null : owner.getColor());
         builder.setDescription(str);
-        event.reply(new MessageBuilder().append(title).setEmbeds(builder.build()).build());
+        event.reply(new MessageCreateBuilder().setContent(title).setEmbeds(builder.build()).build());
     }
 }

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/ButtonEmbedPaginator.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/ButtonEmbedPaginator.java
@@ -17,7 +17,6 @@ package com.jagrosh.jdautilities.menu;
 
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -28,6 +27,9 @@ import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageEditData;
 import net.dv8tion.jda.internal.utils.Checks;
 import org.slf4j.LoggerFactory;
 
@@ -112,7 +114,7 @@ public class ButtonEmbedPaginator extends Menu {
             pageNum = 1;
         else if (pageNum > embeds.size())
             pageNum = embeds.size();
-        Message msg = renderPage(pageNum);
+        MessageCreateData msg = MessageCreateData.fromEditData(renderPage(pageNum));
         initialize(channel.sendMessage(msg), pageNum);
     }
 
@@ -128,7 +130,7 @@ public class ButtonEmbedPaginator extends Menu {
             pageNum = 1;
         else if (pageNum > embeds.size())
             pageNum = embeds.size();
-        Message msg = renderPage(pageNum);
+        MessageEditData msg = renderPage(pageNum);
         initialize(message.editMessage(msg), pageNum);
     }
 
@@ -234,17 +236,17 @@ public class ButtonEmbedPaginator extends Menu {
         }
 
         int n = newPageNum;
-        event.deferEdit().queue(interactionHook -> {
-            message.editMessage(renderPage(n)).setActionRow(buildButtons()).queue(m -> pagination(m, n));
-        });
+        event.deferEdit().queue(
+            interactionHook -> message.editMessage(renderPage(n)).setActionRow(buildButtons()).queue(m -> pagination(m, n))
+        );
     }
 
-    private Message renderPage(int pageNum) {
-        MessageBuilder mbuilder = new MessageBuilder();
+    private MessageEditData renderPage(int pageNum) {
+        MessageEditBuilder mbuilder = new MessageEditBuilder();
         MessageEmbed membed = this.embeds.get(pageNum - 1);
         mbuilder.setEmbeds(membed);
         if (text != null)
-            mbuilder.append(text.apply(pageNum, embeds.size()));
+            mbuilder.setContent(text.apply(pageNum, embeds.size()));
         return mbuilder.build();
     }
 

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/ButtonMenu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/ButtonMenu.java
@@ -17,7 +17,6 @@ package com.jagrosh.jdautilities.menu;
 
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.Role;
@@ -25,6 +24,9 @@ import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageEditData;
 import net.dv8tion.jda.internal.utils.Checks;
 
 import java.awt.Color;
@@ -72,7 +74,7 @@ public class ButtonMenu extends Menu
     @Override
     public void display(MessageChannel channel)
     {
-        initialize(channel.sendMessage(getMessage()));
+        initialize(channel.sendMessage(MessageCreateData.fromEditData(getMessage())));
     }
 
     /**
@@ -145,11 +147,11 @@ public class ButtonMenu extends Menu
     }
 
     // Generates a ButtonMenu message
-    private Message getMessage()
+    private MessageEditData getMessage()
     {
-        MessageBuilder mbuilder = new MessageBuilder();
+        MessageEditBuilder mbuilder = new MessageEditBuilder();
         if(text!=null)
-            mbuilder.append(text);
+            mbuilder.setContent(text);
         if(description!=null)
             mbuilder.setEmbeds(new EmbedBuilder().setColor(color).setDescription(description).build());
         return mbuilder.build();

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/EmbedPaginator.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/EmbedPaginator.java
@@ -17,7 +17,6 @@ package com.jagrosh.jdautilities.menu;
 
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.message.GenericMessageEvent;
@@ -25,6 +24,9 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.exceptions.PermissionException;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageEditData;
 import net.dv8tion.jda.internal.utils.Checks;
 
 import java.util.*;
@@ -119,8 +121,8 @@ public class EmbedPaginator extends Menu{
             pageNum = 1;
         else if(pageNum > embeds.size())
             pageNum = embeds.size();
-        Message msg = renderPage(pageNum);
-        initialize(channel.sendMessage(msg), pageNum);
+        MessageEditData msg = renderPage(pageNum);
+        initialize(channel.sendMessage(MessageCreateData.fromEditData(msg)), pageNum);
     }
 
     /**
@@ -139,7 +141,7 @@ public class EmbedPaginator extends Menu{
             pageNum = 1;
         else if(pageNum > embeds.size())
             pageNum = embeds.size();
-        Message msg = renderPage(pageNum);
+        MessageEditData msg = renderPage(pageNum);
         initialize(message.editMessage(msg), pageNum);
     }
 
@@ -309,13 +311,13 @@ public class EmbedPaginator extends Menu{
         message.editMessage(renderPage(newPageNum)).queue(m -> pagination(m, n));
     }
 
-    private Message renderPage(int pageNum)
+    private MessageEditData renderPage(int pageNum)
     {
-        MessageBuilder mbuilder = new MessageBuilder();
+        MessageEditBuilder mbuilder = new MessageEditBuilder();
         MessageEmbed membed = this.embeds.get(pageNum-1);
         mbuilder.setEmbeds(membed);
         if(text != null)
-            mbuilder.append(text.apply(pageNum, embeds.size()));
+            mbuilder.setContent(text.apply(pageNum, embeds.size()));
         return mbuilder.build();
     }
 

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/OrderedMenu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/OrderedMenu.java
@@ -26,7 +26,6 @@ import java.util.function.Consumer;
 
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.Message;
@@ -40,6 +39,9 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.exceptions.PermissionException;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageEditData;
 import net.dv8tion.jda.internal.utils.Checks;
 
 /**
@@ -116,7 +118,7 @@ public class OrderedMenu extends Menu
                 && !allowTypedInput
                 && !((TextChannel)channel).getGuild().getSelfMember().hasPermission((TextChannel) channel, Permission.MESSAGE_ADD_REACTION))
             throw new PermissionException("Must be able to add reactions if not allowing typed input!");
-        initialize(channel.sendMessage(getMessage()));
+        initialize(channel.sendMessage(MessageCreateData.fromEditData(getMessage())));
     }
 
     /**
@@ -262,11 +264,11 @@ public class OrderedMenu extends Menu
     }
 
     // This is where the displayed message for the OrderedMenu is built.
-    private Message getMessage()
+    private MessageEditData getMessage()
     {
-        MessageBuilder mbuilder = new MessageBuilder();
+        MessageEditBuilder mbuilder = new MessageEditBuilder();
         if(text!=null)
-            mbuilder.append(text);
+            mbuilder.setContent(text);
         StringBuilder sb = new StringBuilder();
         for(int i=0; i<choices.size(); i++)
             sb.append("\n").append(getEmoji(i)).append(" ").append(choices.get(i));

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/Paginator.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/Paginator.java
@@ -26,7 +26,6 @@ import java.util.function.Consumer;
 
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.Role;
@@ -37,6 +36,9 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.exceptions.PermissionException;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageEditData;
 import net.dv8tion.jda.internal.utils.Checks;
 
 /**
@@ -154,8 +156,8 @@ public class Paginator extends Menu
             pageNum = 1;
         else if (pageNum>pages)
             pageNum = pages;
-        Message msg = renderPage(pageNum);
-        initialize(channel.sendMessage(msg), pageNum);
+        MessageEditData msg = renderPage(pageNum);
+        initialize(channel.sendMessage(MessageCreateData.fromEditData(msg)), pageNum);
     }
 
     /**
@@ -174,7 +176,7 @@ public class Paginator extends Menu
             pageNum = 1;
         else if (pageNum>pages)
             pageNum = pages;
-        Message msg = renderPage(pageNum);
+        MessageEditData msg = renderPage(pageNum);
         initialize(message.editMessage(msg), pageNum);
     }
 
@@ -358,12 +360,12 @@ public class Paginator extends Menu
         message.editMessage(renderPage(newPageNum)).queue(m -> pagination(m, n));
     }
 
-    private Message renderPage(int pageNum)
+    private MessageEditData renderPage(int pageNum)
     {
-        MessageBuilder mbuilder = new MessageBuilder();
+        MessageEditBuilder mbuilder = new MessageEditBuilder();
         EmbedBuilder ebuilder = new EmbedBuilder();
         int start = (pageNum-1)*itemsPerPage;
-        int end = strings.size() < pageNum*itemsPerPage ? strings.size() : pageNum*itemsPerPage;
+        int end = Math.min(strings.size(), pageNum * itemsPerPage);
         if(columns == 1)
         {
             StringBuilder sbuilder = new StringBuilder();
@@ -388,7 +390,7 @@ public class Paginator extends Menu
             ebuilder.setFooter("Page "+pageNum+"/"+pages, null);
         mbuilder.setEmbeds(ebuilder.build());
         if(text!=null)
-            mbuilder.append(text.apply(pageNum, pages));
+            mbuilder.setContent(text.apply(pageNum, pages));
         return mbuilder.build();
     }
 

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
@@ -27,7 +27,6 @@ import java.util.function.Function;
 
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.Role;
@@ -36,6 +35,9 @@ import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.exceptions.PermissionException;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageEditData;
 import net.dv8tion.jda.internal.utils.Checks;
 
 /**
@@ -137,8 +139,8 @@ public class SelectionDialog extends Menu
             selection = 1;
         else if(selection>choices.size())
             selection = choices.size();
-        Message msg = render(selection);
-        initialize(channel.sendMessage(msg), selection);
+        MessageEditData msg = render(selection);
+        initialize(channel.sendMessage(MessageCreateData.fromEditData(msg)), selection);
     }
 
     /**
@@ -157,7 +159,7 @@ public class SelectionDialog extends Menu
             selection = 1;
         else if(selection>choices.size())
             selection = choices.size();
-        Message msg = render(selection);
+        MessageEditData msg = render(selection);
         initialize(message.editMessage(msg), selection);
     }
 
@@ -224,7 +226,7 @@ public class SelectionDialog extends Menu
         }, timeout, unit, () -> cancel.accept(message));
     }
 
-    private Message render(int selection)
+    private MessageEditData render(int selection)
     {
         StringBuilder sbuilder = new StringBuilder();
         for(int i=0; i<choices.size(); i++)
@@ -232,10 +234,10 @@ public class SelectionDialog extends Menu
                 sbuilder.append("\n").append(leftEnd).append(choices.get(i)).append(rightEnd);
             else
                 sbuilder.append("\n").append(defaultLeft).append(choices.get(i)).append(defaultRight);
-        MessageBuilder mbuilder = new MessageBuilder();
+        MessageEditBuilder mbuilder = new MessageEditBuilder();
         String content = text.apply(selection);
         if(content!=null)
-            mbuilder.append(content);
+            mbuilder.setContent(content);
         return mbuilder.setEmbeds(new EmbedBuilder()
                 .setColor(color.apply(selection))
                 .setDescription(sbuilder.toString())

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/Slideshow.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/Slideshow.java
@@ -26,7 +26,6 @@ import java.util.function.Consumer;
 
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.Role;
@@ -37,6 +36,9 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.exceptions.PermissionException;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageEditData;
 import net.dv8tion.jda.internal.utils.Checks;
 
 /**
@@ -135,8 +137,8 @@ public class Slideshow extends Menu
             pageNum = 1;
         else if (pageNum>urls.size())
             pageNum = urls.size();
-        Message msg = renderPage(pageNum);
-        initialize(channel.sendMessage(msg), pageNum);
+        MessageEditData msg = renderPage(pageNum);
+        initialize(channel.sendMessage(MessageCreateData.fromEditData(msg)), pageNum);
     }
 
     /**
@@ -155,7 +157,7 @@ public class Slideshow extends Menu
             pageNum = 1;
         else if (pageNum>urls.size())
             pageNum = urls.size();
-        Message msg = renderPage(pageNum);
+        MessageEditData msg = renderPage(pageNum);
         initialize(message.editMessage(msg), pageNum);
     }
 
@@ -337,9 +339,9 @@ public class Slideshow extends Menu
         message.editMessage(renderPage(newPageNum)).queue(m -> pagination(m, n));
     }
 
-    private Message renderPage(int pageNum)
+    private MessageEditData renderPage(int pageNum)
     {
-        MessageBuilder mbuilder = new MessageBuilder();
+        MessageEditBuilder mbuilder = new MessageEditBuilder();
         EmbedBuilder ebuilder = new EmbedBuilder();
         ebuilder.setImage(urls.get(pageNum-1));
         ebuilder.setColor(color.apply(pageNum, urls.size()));
@@ -348,7 +350,7 @@ public class Slideshow extends Menu
             ebuilder.setFooter("Image "+pageNum+"/"+urls.size(), null);
         mbuilder.setEmbeds(ebuilder.build());
         if(text!=null)
-            mbuilder.append(text.apply(pageNum, urls.size()));
+            mbuilder.setContent(text.apply(pageNum, urls.size()));
         return mbuilder.build();
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [ ] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `command` and `menu` module of the JDA-Chewtils library.
- [ ] My PR creates a new module for the JDA-Chewtils library: `______`.

#### Description

Updates Chewtils to support the latest Message changes made in JDA v5.
Methods using `Message` instances as vars (i.e. `reply(Message)`) have been updated to use `MessageCreateData` instances instead.

`respond(File, String, AttachmentOption...)` was changed to `respond(File, String, String, boolean)` due to `AttachmentOption` being removed.
The new method now uses the second String for the description (Set to null or empty for no description) and the boolean to mark as spoiler.

I'll leave this PR as a draft until the next Alpha is dropped by JDA that implements it completely, so that we have a proper version to support and not just a commit.
(I mainly made this change to use it in my bot :P)