### PR TITLE
Fix slash command children in groups matching children with the same name

### DIFF
--- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
@@ -969,13 +969,13 @@ public class CommandClientImpl implements CommandClient, EventListener
             case 2: // Slash command with children
                 // child check
                 for(SlashCommand cmd: command.getChildren())
-                    if(cmd.isCommandFor(parts[1]))
+                    if(cmd.isCommandFor(parts[1]) && cmd.getSubcommandGroup() == null)
                         return cmd;
 
                 return null;
             case 3: // Slash command with a group and a child
                 for(SlashCommand cmd: command.getChildren())
-                    if(cmd.isCommandFor(parts[2]) && cmd.getSubcommandGroup().getName().equals(parts[1]))
+                    if(cmd.isCommandFor(parts[2]) && cmd.getSubcommandGroup() != null && cmd.getSubcommandGroup().getName().equals(parts[1]))
                         return cmd;
 
                 return null;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [X] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [X] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [X] My PR fixes a bug, error, or other issue with the library's codebase.
- [X] My PR is for the `commands` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

Currently, when checking if a slash command children matches the interaction, the client does not properly check if the child is in not in a group. This PR fixes that by making sure that a command with a child only matches children without a subcommand, and that slash commands with children and a group match the same group, and do not throw NPEs while checking.
