### PR TITLE
Fix oauth 2 breaking on JDA Beta7 onwards

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
     version = versionInfo.values().join('.')
 
     ext {
-        jdaVersion = '5.0.0-beta.2'
+        jdaVersion = '5.0.0-beta.7'
         slf4jVersion = '1.7.36'
         okhttpVersion = '4.9.3'
         findbugsVersion = '3.0.2'

--- a/oauth2/src/main/java/com/jagrosh/jdautilities/oauth2/entities/impl/OAuth2ClientImpl.java
+++ b/oauth2/src/main/java/com/jagrosh/jdautilities/oauth2/entities/impl/OAuth2ClientImpl.java
@@ -31,7 +31,7 @@ import com.jagrosh.jdautilities.oauth2.session.SessionData;
 import com.jagrosh.jdautilities.oauth2.state.DefaultStateController;
 import com.jagrosh.jdautilities.oauth2.state.StateController;
 import net.dv8tion.jda.api.exceptions.HttpException;
-import net.dv8tion.jda.internal.requests.Method;
+import net.dv8tion.jda.api.requests.Method;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EncodingUtil;
 import net.dv8tion.jda.internal.utils.IOUtil;

--- a/oauth2/src/main/java/com/jagrosh/jdautilities/oauth2/requests/OAuth2Action.java
+++ b/oauth2/src/main/java/com/jagrosh/jdautilities/oauth2/requests/OAuth2Action.java
@@ -16,7 +16,7 @@
 package com.jagrosh.jdautilities.oauth2.requests;
 
 import com.jagrosh.jdautilities.oauth2.entities.impl.OAuth2ClientImpl;
-import net.dv8tion.jda.internal.requests.Method;
+import net.dv8tion.jda.api.requests.Method;
 import net.dv8tion.jda.internal.utils.Checks;
 import okhttp3.Headers;
 import okhttp3.Request;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [x] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `oAuth` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description
This PR fixes the change that JDA did by moving a .java file (Method.java) from net.dv8tion.jda.internal.requests.Method to import net.dv8tion.jda.api.requests.Method; 
Fixes: #82
