### PR TITLE
Make SlashCommand#getHelp() return translated text when available.

### DIFF
--- a/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
@@ -198,7 +198,7 @@ public abstract class SlashCommand extends Command
      * @return Translated Help text for default locale, or help text set in constructor.
      */
     @Override
-    public String getHelp(){
+    public String getHelp() {
         String helpMessage = null;
         if (!getDescriptionLocalization().isEmpty()) {
             helpMessage = getDescriptionLocalization().get(TranslateUtil.getDefaultLocale());

--- a/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
@@ -15,6 +15,7 @@
  */
 package com.jagrosh.jdautilities.command;
 
+import com.jagrosh.jdautilities.commons.utils.TranslateUtil;
 import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.GuildVoiceState;
@@ -177,6 +178,24 @@ public abstract class SlashCommand extends Command
      */
     @Override
     protected void execute(CommandEvent event) {}
+    
+    /**
+     * Returns the description of this SlashCommand instance.<br>
+     * Should there be {@link #getDescriptionLocalization() translations for this text} will the client try to
+     * obtain a translation for the Description using {@link TranslateUtil#getDefaultLocale() the default locale} and
+     * in case of a null or empty String return the default help text set.
+     * 
+     * @return Translated Help text for default locale, or help text set in constructor.
+     */
+    @Override
+    public String getHelp(){
+        String helpMessage = null;
+        if (!getDescriptionLocalization().isEmpty()) {
+            helpMessage = getDescriptionLocalization().get(TranslateUtil.getDefaultLocale());
+        }
+        
+        return (helpMessage == null || helpMessage.isEmpty()) ? this.help : helpMessage;
+    }
 
     /**
      * Runs checks for the {@link SlashCommand SlashCommand} with the

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/TranslateUtil.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/TranslateUtil.java
@@ -66,7 +66,7 @@ public class TranslateUtil {
 
     /**
      * Converts the following key to the provided locale. Will default to {@code DEFAULT} if no locale.<br>
-     * Recommended use: {@code t("MY_KEY", event.getUserLocale())} on interactions.
+     * Recommended use: {@code t(event.getUserLocale(), "MY_KEY")} on interactions.
      *
      * @param locale The locale to convert to
      * @param key The key to convert
@@ -96,5 +96,15 @@ public class TranslateUtil {
         }
 
         return locales;
+    }
+    
+    /**
+     * Returns the Default locale set to use by this TranslateUtil. By default is the default locale {@link DiscordLocale#ENGLISH_US}
+     * but may be changed using {@link #setDefaultLocale(DiscordLocale)}
+     * 
+     * @return The Default DiscordLocale used by this TranslateUtil.
+     */
+    public static DiscordLocale getDefaultLocale() {
+        return DEFAULT;
     }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [ ] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `commands` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

This overrides the `getHelp()` method to return a translated description using the default locale through `getDescriptionLocalization().get(TranslateUtil.getDefaultLocale)`
This should allow a user to set the description within the localization files without needing to set the `help` text itself.
Should there be no localized description for the default locale (Be null or empty) will it default to using `this.help`

This also adds `getDefaultLocale()` in the TranslateUtil to retrieve the default locale that was set.

I didn't add the same functionality to the name, as names in SlashCommands need to be alphanummeric when creating, which with this aproach would be problematic.

Given that this overrides a method for SlashCommand, should it automatically also be applied to Subcommands too.

Closes #89 