### PR TITLE
Add "always respect user permissions" field

### DIFF
--- a/command/src/main/java/com/jagrosh/jdautilities/command/ContextMenu.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/ContextMenu.java
@@ -64,6 +64,16 @@ public abstract class ContextMenu extends Interaction
     }
 
     /**
+     * {@code true} if the command should always respect user permissions, even if the server overrides them,
+     * {@code false} if the command should ignore user permissions if the server overrides them.
+     * <br>
+     * This defaults to false because it interferes with the server's options for interactions.
+     * <br>
+     * This has no effect for text based commands or DMs.
+     */
+    protected boolean alwaysRespectUserPermissions = false;
+
+    /**
      * Gets the type of context menu.
      *
      * @return the type

--- a/command/src/main/java/com/jagrosh/jdautilities/command/ContextMenu.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/ContextMenu.java
@@ -64,14 +64,14 @@ public abstract class ContextMenu extends Interaction
     }
 
     /**
-     * {@code true} if the command should always respect user permissions, even if the server overrides them,
-     * {@code false} if the command should ignore user permissions if the server overrides them.
+     * {@code true} if the command should always respect {@link #userPermissions}, even if the server overrides them,
+     * {@code false} if the command should ignore {@link #userPermissions} if the server overrides them.
      * <br>
      * This defaults to false because it interferes with the server's options for interactions.
      * <br>
      * This has no effect for text based commands or DMs.
      */
-    protected boolean alwaysRespectUserPermissions = false;
+    protected boolean forceUserPermissions = false;
 
     /**
      * Gets the type of context menu.

--- a/command/src/main/java/com/jagrosh/jdautilities/command/MessageContextMenu.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/MessageContextMenu.java
@@ -58,29 +58,30 @@ public abstract class MessageContextMenu extends ContextMenu
         if(event.isFromGuild())
         {
             //user perms
-            for(Permission p: userPermissions)
-            {
-                // Member will never be null because this is only ran in a server (text channel)
-                if(event.getMember() == null)
-                    continue;
+            if (alwaysRespectUserPermissions)
+                for(Permission p: userPermissions)
+                {
+                    // Member will never be null because this is only ran in a server (text channel)
+                    if(event.getMember() == null)
+                        continue;
 
-                if(p.isChannel())
-                {
-                    if(!event.getMember().hasPermission(event.getGuildChannel(), p))
+                    if(p.isChannel())
                     {
-                        terminate(event, String.format("%s%s%s", event.getClient().getError(), p.getName(), "channel"));
-                        return;
+                        if(!event.getMember().hasPermission(event.getGuildChannel(), p))
+                        {
+                            terminate(event, String.format("%s%s%s", event.getClient().getError(), p.getName(), "channel"));
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        if(!event.getMember().hasPermission(p))
+                        {
+                            terminate(event, String.format("%s%s%s", event.getClient().getError(), p.getName(), "server"));
+                            return;
+                        }
                     }
                 }
-                else
-                {
-                    if(!event.getMember().hasPermission(p))
-                    {
-                        terminate(event, String.format("%s%s%s", event.getClient().getError(), p.getName(), "server"));
-                        return;
-                    }
-                }
-            }
 
             // bot perms
             for(Permission p: botPermissions)

--- a/command/src/main/java/com/jagrosh/jdautilities/command/MessageContextMenu.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/MessageContextMenu.java
@@ -58,7 +58,8 @@ public abstract class MessageContextMenu extends ContextMenu
         if(event.isFromGuild())
         {
             //user perms
-            if (alwaysRespectUserPermissions)
+            if (forceUserPermissions)
+            {
                 for(Permission p: userPermissions)
                 {
                     // Member will never be null because this is only ran in a server (text channel)
@@ -82,6 +83,7 @@ public abstract class MessageContextMenu extends ContextMenu
                         }
                     }
                 }
+            }
 
             // bot perms
             for(Permission p: botPermissions)

--- a/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
@@ -100,14 +100,14 @@ public abstract class SlashCommand extends Command
     protected String requiredRole = null;
 
     /**
-     * {@code true} if the command should always respect user permissions, even if the server overrides them,
-     * {@code false} if the command should ignore user permissions if the server overrides them.
+     * {@code true} if the command should always respect {@link #userPermissions}, even if the server overrides them,
+     * {@code false} if the command should ignore {@link #userPermissions} if the server overrides them.
      * <br>
      * This defaults to false because it interferes with the server's options for interactions.
      * <br>
      * This has no effect for text based commands or DMs.
      */
-    protected boolean alwaysRespectUserPermissions = false;
+    protected boolean forceUserPermissions = false;
 
     /**
      * The child commands of the command. These are used in the format {@code /<parent name>
@@ -231,7 +231,8 @@ public abstract class SlashCommand extends Command
         if(event.getChannelType() != ChannelType.PRIVATE)
         {
             //user perms
-            if (alwaysRespectUserPermissions)
+            if (forceUserPermissions)
+            {
                 for(Permission p: userPermissions)
                 {
                     // Member will never be null because this is only ran in a server (text channel)
@@ -255,6 +256,7 @@ public abstract class SlashCommand extends Command
                         }
                     }
                 }
+            }
 
             // bot perms
             for(Permission p: botPermissions)

--- a/command/src/main/java/com/jagrosh/jdautilities/command/UserContextMenu.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/UserContextMenu.java
@@ -95,7 +95,8 @@ public abstract class UserContextMenu extends ContextMenu
         if(event.isFromGuild())
         {
             //user perms
-            if (alwaysRespectUserPermissions)
+            if (forceUserPermissions)
+            {
                 for(Permission p: userPermissions)
                 {
                     // Member will never be null because this is only ran in a server
@@ -119,6 +120,7 @@ public abstract class UserContextMenu extends ContextMenu
                         }
                     }
                 }
+            }
 
             // bot perms
             for(Permission p: botPermissions)

--- a/command/src/main/java/com/jagrosh/jdautilities/command/UserContextMenu.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/UserContextMenu.java
@@ -95,29 +95,30 @@ public abstract class UserContextMenu extends ContextMenu
         if(event.isFromGuild())
         {
             //user perms
-            for(Permission p: userPermissions)
-            {
-                // Member will never be null because this is only ran in a server
-                if(event.getMember() == null)
-                    continue;
+            if (alwaysRespectUserPermissions)
+                for(Permission p: userPermissions)
+                {
+                    // Member will never be null because this is only ran in a server
+                    if(event.getMember() == null)
+                        continue;
 
-                if(p.isChannel())
-                {
-                    if(!event.getMember().hasPermission(event.getGuildChannel(), p))
+                    if(p.isChannel())
                     {
-                        terminate(event, String.format("%s%s%s", event.getClient().getError(), p.getName(), "channel"));
-                        return;
+                        if(!event.getMember().hasPermission(event.getGuildChannel(), p))
+                        {
+                            terminate(event, String.format("%s%s%s", event.getClient().getError(), p.getName(), "channel"));
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        if(!event.getMember().hasPermission(p))
+                        {
+                            terminate(event, String.format("%s%s%s", event.getClient().getError(), p.getName(), "server"));
+                            return;
+                        }
                     }
                 }
-                else
-                {
-                    if(!event.getMember().hasPermission(p))
-                    {
-                        terminate(event, String.format("%s%s%s", event.getClient().getError(), p.getName(), "server"));
-                        return;
-                    }
-                }
-            }
 
             // bot perms
             for(Permission p: botPermissions)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [ ] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `commands` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

This adds a field for interactions that allows the userPermissions checks to be skipped. They aren't necessary on servers because you can override them in the integration settings, and if left unset, the userPermissions set will take precedent anyway. The most breaking change is it's false by default, but no one will notice.