### PR TITLE
Support for JDA 6.1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
         java: [8, 11, 17]
       fail-fast: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
     version = versionInfo.values().join('.')
 
     ext {
-        jdaVersion = '5.3.0'
+        jdaVersion = '6.0.0-rc.1'
         slf4jVersion = '1.7.36'
         okhttpVersion = '4.9.3'
         findbugsVersion = '3.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
     version = versionInfo.values().join('.')
 
     ext {
-        jdaVersion = '6.0.0-rc.1'
+        jdaVersion = '6.1.1'
         slf4jVersion = '1.7.36'
         okhttpVersion = '4.9.3'
         findbugsVersion = '3.0.2'

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/ButtonEmbedPaginator.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/ButtonEmbedPaginator.java
@@ -17,6 +17,9 @@ package com.jagrosh.jdautilities.menu;
 
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.Role;
@@ -25,8 +28,6 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.interactions.InteractionHook;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
-import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
@@ -169,19 +170,20 @@ public class ButtonEmbedPaginator extends Menu {
     private void initialize(RestAction<Message> action, int pageNum) {
         action.queue(m -> {
             if (embeds.size() > 1) {
-                List<Button> actions = buildButtons();
+                ActionRow actions = buildButtons();
 
-                m.editMessage(renderPage(pageNum)).setActionRow(actions).queue(v -> pagination(m, pageNum));
+                m.editMessage(renderPage(pageNum)).setComponents(actions).queue(v -> pagination(m, pageNum));
             } else if (waitOnSinglePage) {
                 String id = System.currentTimeMillis() + ":STOP";
-                m.editMessage(renderPage(pageNum)).setActionRow(Button.of(style, id, STOP)).queue(v -> pagination(m, pageNum));
+                ActionRow button = ActionRow.of(Button.of(style, id, STOP));
+                m.editMessage(renderPage(pageNum)).setComponents(button).queue(v -> pagination(m, pageNum));
             } else {
                 finalAction.accept(m);
             }
         });
     }
 
-    private List<Button> buildButtons() {
+    private ActionRow buildButtons() {
         // bep = button embed paginator
         String id = "bep:" + System.currentTimeMillis();
         List<Button> actions = new ArrayList<>();
@@ -194,7 +196,7 @@ public class ButtonEmbedPaginator extends Menu {
             actions.add(Button.of(style, id + ":BIG_RIGHT", BIG_RIGHT));
         }
 
-        return actions;
+        return ActionRow.of(actions);
     }
 
     private void pagination(Message message, int pageNum) {
@@ -271,7 +273,7 @@ public class ButtonEmbedPaginator extends Menu {
 
         int n = newPageNum;
         event.deferEdit().queue(
-            interactionHook -> message.editMessage(renderPage(n)).setActionRow(buildButtons()).queue(m -> pagination(m, n))
+            interactionHook -> message.editMessage(renderPage(n)).setComponents(buildButtons()).queue(m -> pagination(m, n))
         );
     }
 


### PR DESCRIPTION

[pull-request]: https://github.com/Chew/JDA-Chewtils/pulls

## Pull Request

#### Pull Request Checklist

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.

#### Pull Request Information

- [x] My PR fixes a bug, error, or other issue with the library's codebase.
- [ ] My PR is for the `______` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description
This PR builds on https://github.com/Chew/JDA-Chewtils/pull/93 and updates the `jdaVersion` in `build.gradle` to **JDA 6.1.1** (the current stable release at time of writing).

The referenced PR compiles against an earlier JDA 6 RC, but at runtime when using an actual release like 6.1.1 the following error occurs:

```
java.lang.NoSuchMethodError: 'net.dv8tion.jda.api.entities.Member net.dv8tion.jda.api.entities.Guild.getSelfMember()'
at com.jagrosh.jdautilities.command.CommandEvent.getSelfMember(CommandEvent.java:1055)
```

This is likely due to API differences between the RC and the JDA releases. Updating the dependency version resolves the issue.

My commit contains no other functional changes besides the version bump needed for compatibility with current JDA versions.



