### PR TITLE
Update okhttp, so that it works together used by JDA 6.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ allprojects {
     ext {
         jdaVersion = '6.1.1'
         slf4jVersion = '1.7.36'
-        okhttpVersion = '4.9.3'
+        okhttpVersion = '5.3.2'
         findbugsVersion = '3.0.2'
         jsonVersion = '20220320'
         junitVersion = '4.13.1' // TODO Move to junit 5?


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Yes, I've cheched for other pull requests solving this

#### Description

Just a simple update of okhttp, so that one doesn't get errors due to version conflicts as JDA 6.1.1 use a new version on the lib.
